### PR TITLE
Use a shallow clone when doing the initial environment setup

### DIFF
--- a/tasks/ansible_user_env_setup.yml
+++ b/tasks/ansible_user_env_setup.yml
@@ -42,6 +42,7 @@
     repo: "{{ git_repo_url }}"
     dest: "/home/{{ ansible_username }}/{{ project_name }}"
     version: "{{ git_repo_branch }}"
+    depth: 1
 
 - name: Create symbolic link in project for .env.production
   file:


### PR DESCRIPTION
A shallow clone is all that's required to do an initial deploy, we don't need to check out the entire project history and all of the branches.