### PR TITLE
Convert shallow git checkout

### DIFF
--- a/tasks/ansible_user_env_setup.yml
+++ b/tasks/ansible_user_env_setup.yml
@@ -44,6 +44,13 @@
     version: "{{ git_repo_branch }}"
     depth: 1
 
+- name: Convert shallow clone to full clone for developers
+  become_user: "{{ ansible_username }}"
+  shell: >
+    cd "/home/{{ ansible_username }}/{{ project_name }}"; /usr/bin/git fetch --unshallow
+  ignore_errors: true
+  tags: [ 'never', 'development' ]
+
 - name: Create symbolic link in project for .env.production
   file:
     src: "{{ capistrano_base}}/{{ project_name }}/shared/.env.production"


### PR DESCRIPTION
Line 45 tells git to do a shallow clone to save time. Because the version of git in RHEL/CentOS is older, though, this depth variable is actually ignored.

    box: TASK [uclalib_role_samvera_capdeploy : Obtain a fresh clone of the project's git repository] ***
    box:  [WARNING]: Your git version is too old to fully support the depth argument.
    box: Falling back to full checkouts.

As it is, `depth` doesn't do anything and a full checkout is still done. Leaving the `depth` argument in, though, means that at some point in the future, when RHEL/CentOS' git version is updated, that the clone will be a shallow clone. This will save build time, but it's not what a developer's box wants so I've added a task below this that will convert the git checkout to a full checkout for the dev box only (using Ansible tags).

Right now this fails because the git clone isn't shallow, but I've added an ignore_errors to let it to live happily in the role until the point when it's needed.

Another option would be to remove the `depth` variable and the extra task, but it's a good thing for CI and CD when it works so I've opted to keep it in. You also could remove them and add them in later when the version of git is updated as another option (though we'll have to remember to add them both back in).
