### PR TITLE
Removing git clone depth parameter

### DIFF
--- a/tasks/ansible_user_env_setup.yml
+++ b/tasks/ansible_user_env_setup.yml
@@ -42,7 +42,6 @@
     repo: "{{ git_repo_url }}"
     dest: "/home/{{ ansible_username }}/{{ project_name }}"
     version: "{{ git_repo_branch }}"
-    depth: 1
 
 - name: Create symbolic link in project for .env.production
   file:


### PR DESCRIPTION
Based on comments for @ksclarke and @hardyoyo I am removing the git clone depth parameter as it does not do anything at this point. If we deem appropriate, we can add it back at a later time. 