### PR TITLE
55-allow-devbox-shutdown

### DIFF
--- a/files/00-stop-reboot.rules
+++ b/files/00-stop-reboot.rules
@@ -1,0 +1,23 @@
+polkit.addRule(function(action, subject) {
+  if (action.id.indexOf("org.freedesktop.login1.hibernate") == 0) {
+    return polkit.Result.AUTH_ADMIN;
+  }
+});
+
+polkit.addRule(function(action, subject) {
+  if (action.id.indexOf("org.freedesktop.login1.power-off") == 0) {
+    return polkit.Result.AUTH_ADMIN;
+  }
+});
+
+polkit.addRule(function(action, subject) {
+  if (action.id.indexOf("org.freedesktop.login1.reboot") == 0) {
+    return polkit.Result.AUTH_ADMIN;
+  }
+});
+
+polkit.addRule(function(action, subject) {
+  if (action.id.indexOf("org.freedesktop.login1.suspend") == 0) {
+    return polkit.Result.AUTH_ADMIN;
+  }
+});

--- a/tasks/ansible_user_env_setup.yml
+++ b/tasks/ansible_user_env_setup.yml
@@ -63,3 +63,12 @@
     dest: "/home/{{ ansible_user }}/{{ project_name }}/.env.test"
     state: link
   tags: [ 'never', 'development' ]
+
+- name: Allow dev user to shutdown the machine
+  copy:
+    src: "00-stop-reboot.rules"
+    dest: "/etc/polkit-1/rules.d/00-stop-reboot.rules"
+    owner: root
+    group: root
+    mode: 0644
+  tags: [ 'never', 'development' ]


### PR DESCRIPTION
This PR gives the developer's box user the ability to shutdown the VM via `vagrant halt`. It only runs for the developer's box build.